### PR TITLE
Compatiblity with planet packs

### DIFF
--- a/Source/ModuleIRSurfaceSampler.cs
+++ b/Source/ModuleIRSurfaceSampler.cs
@@ -304,17 +304,20 @@ namespace IRSurfaceSampler
 				}
 
 				Transform hitT = hit.collider.transform;
+                Transform vesselMainbodyT = vessel.mainBody.GetTransform(); 
 				int i = 0;
 
 				//This loop keeps moving up the chain looking for a transform with a name that matches the current celestial body's name; it stops at a certain point
-				while (hitT != null && i < 100)
+
+                while (hitT != null && i < 100)
 				{
-					if (hitT.name.Contains(vessel.mainBody.name))
+                    if (hitT.name.Contains(vesselMainbodyT.name))
 						return true;
 					hitT = hitT.parent;
 					i++;
 				}
 			}
+
 
 			return false;
 		}


### PR DESCRIPTION
Planet pack mods like galileo planet pack cant change the internal name of Kerbin since that would break the game.

Comparing hitT.name with vessel.mainBody.name will always fail on a "renamed" kerbin since the Transforms name stays "Kerbin", while vessel.mainBody.name will be whatever the mod chooses as display name.

Checking the name of vessel.mainBody.getTransform instead solves this.
